### PR TITLE
Add Rust wat/wast crate implementation

### DIFF
--- a/proposals/wat-numeric-values/Overview.md
+++ b/proposals/wat-numeric-values/Overview.md
@@ -33,6 +33,7 @@ For example:
 * Compilers that have implemented this proposal:
 
     - [wasp](https://github.com/WebAssembly/wasp) (use `--enable-numeric-values` flag)
+    - [Rust `wat`/`wast` crates](https://github.com/bytecodealliance/wasm-tools)
 
 ## Motivation
 


### PR DESCRIPTION
Figured it was worthwhile to note that this was implemented in https://github.com/bytecodealliance/wasm-tools/pull/147, and hopefully this can also be a data point for agreeing this is a nice feature and it's pretty easy to implement too!